### PR TITLE
Fix wget option (-O not -o), and move any existing ~/.conda to ~/.conda.bak

### DIFF
--- a/conda-move.sh
+++ b/conda-move.sh
@@ -26,7 +26,7 @@ cd $TMPDIR
 if [ -d "$NEW_DIR" ]; then
 	echo "Found existing conda installation in $NEW_DIR, skipping conda installation."
 else
-	wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o Miniconda3-latest-Linux-x86_64.sh
+	wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O Miniconda3-latest-Linux-x86_64.sh
 	bash Miniconda3-latest-Linux-x86_64.sh -b -f -p "${NEW_DIR}"
 fi
 

--- a/conda-move.sh
+++ b/conda-move.sh
@@ -30,6 +30,13 @@ else
 	bash Miniconda3-latest-Linux-x86_64.sh -b -f -p "${NEW_DIR}"
 fi
 
+# In particular, $DOT_CONDA_DIR/environments.txt causes "CondaValueError: prefix already exists: /fast/users/whitewtj_c/scratch/miniconda/envs/blah"
+DOT_CONDA_DIR=$HOME/.conda
+if [ -d "$DOT_CONDA_DIR" ]; then
+	echo "Found existing $DOT_CONDA_DIR, will rename this to $DOT_CONDA_DIR.bak.  Remove it after checking that everything works."
+	mv "$DOT_CONDA_DIR" "$DOT_CONDA_DIR.bak"
+fi
+
 export PATH=$NEW_DIR/bin:$PATH
 
 echo "Step 2) export explicit package lists for all environments in old conda installation ($OLD_DIR)"


### PR DESCRIPTION
Thanks for this great script!  :)

Running it myself in an environment where I had symlinked `~/scratch/miniconda` to `~/work/scratch/miniconda` to keep conda limping along, I noticed a couple of problems:

- wget was actually writing its *log* data to `Miniconda3-latest-Linux-x86_64.sh`, and the script was trying to execute that instead of the downloaded file (which went to `Miniconda3-latest-Linux-x86_64.sh.1`).  An easy fix.
- When it came time to install the detected environments, conda gave me a "CondaValueError: prefix already exists: /fast/users/my_user/scratch/miniconda/envs/some_package" error for each of them, which I put down to there being an existing `~/.conda/environments.txt` file.  The script now detects if `~/.conda` exists, and if it does, moves it to `~/.conda.bak`.

Hope this helps!